### PR TITLE
Fix error: getPinyin, expo audio 

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -20,7 +20,15 @@ export default function RootLayout() {
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen
+          name="(tabs)"
+          options={{
+            headerShown: true,
+            title: 'Home',
+            headerTitle: 'Home',
+            headerTitleStyle: { fontWeight: 'bold' },
+          }}
+        />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/app/quiz.js
+++ b/app/quiz.js
@@ -25,6 +25,7 @@ const Quiz = () => {
 
   return (
     <View>
+    <Text>Question {q + 1} / 10</Text>
       {
         q % 2 == 0 ?
           <MultipleChoiceQuiz />

--- a/app/test.js
+++ b/app/test.js
@@ -5,7 +5,7 @@ import {
 import { useEffect, useState } from 'react'
 import hskData from '@assets/meta/hsk.json';
 import { useStore, useBearsStore } from '@/hooks/useStore';
-import { Audio } from 'expo-audio';
+import { Audio } from 'expo-av';
 import TestTap from '@components/ui/TestTap.js';
 import imgsrc from '@assets/images/finish.png';
 import congrat from '@assets/images/congrat.png';

--- a/app/test.js
+++ b/app/test.js
@@ -150,6 +150,8 @@ const Test = () => {
 
 const styles = StyleSheet.create({
   score: {
+    marginLeft: 18,
+    color: 'red',
     fontSize: 21,
     fontWeight: 600,
   },
@@ -162,7 +164,7 @@ const styles = StyleSheet.create({
   button: {
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 10,
+    padding: 16,
     borderRadius: 4,
     elevation: 3,
     backgroundColor: 'blue',

--- a/components/Tap.js
+++ b/components/Tap.js
@@ -206,10 +206,9 @@ const Tap = (props) => {
                                 {textHanyuDetail}
                             </Text>
                         </TouchableOpacity>
-                        <View style={styles.tapPinyinText} >
-                            {
-                                hanzi.getPinyin(textHanyuDetail)[0] == hanzi.getPinyin(textHanyuDetail)[1]
-                                    ?
+                        <View style={styles.tapPinyinText}>
+                            {(typeof navigator !== 'undefined' && navigator.product === 'ReactNative' && typeof hanzi.getPinyin === 'function') ? (
+                                hanzi.getPinyin(textHanyuDetail)[0] === hanzi.getPinyin(textHanyuDetail)[1] ? (
                                     <Pressable onPress={() => {
                                         playPinyinSound(hanzi.getPinyin(textHanyuDetail)[0])
                                     }}
@@ -217,37 +216,37 @@ const Tap = (props) => {
                                         <Text>{hanzi.getPinyin(textHanyuDetail)[0]}</Text>
                                         <Ionicons name="volume-high" size={23} color="black" />
                                     </Pressable>
-                                    :
+                                ) : (
                                     <View>
-                                        {
-                                            hanzi.getPinyin(textHanyuDetail)[0].charAt(0)
-                                                != hanzi.getPinyin(textHanyuDetail)[0].charAt(0).toUpperCase()
-                                                ?
-                                                <Pressable onPress={() => {
-                                                    playPinyinSound(hanzi.getPinyin(textHanyuDetail)[0])
-                                                }}
-                                                    style={[styles.tapRow, { justifyContent: 'center' }]}><Text>{hanzi.getPinyin(textHanyuDetail)[0]}</Text>
-                                                    <Ionicons name="volume-high" size={23} color="black" />
-                                                </Pressable> : null
-                                        }
+                                        {hanzi.getPinyin(textHanyuDetail)[0].charAt(0) !== hanzi.getPinyin(textHanyuDetail)[0].charAt(0).toUpperCase() ? (
+                                            <Pressable onPress={() => {
+                                                playPinyinSound(hanzi.getPinyin(textHanyuDetail)[0])
+                                            }}
+                                                style={[styles.tapRow, { justifyContent: 'center' }]}>
+                                                <Text>{hanzi.getPinyin(textHanyuDetail)[0]}</Text>
+                                                <Ionicons name="volume-high" size={23} color="black" />
+                                            </Pressable>
+                                        ) : null}
                                         <Pressable onPress={() => {
                                             playPinyinSound(hanzi.getPinyin(textHanyuDetail)[1])
                                         }}
-                                            style={[styles.tapRow, { justifyContent: 'center' }]}><Text>
-                                                {hanzi.getPinyin(textHanyuDetail)[1]}
-                                            </Text>
+                                            style={[styles.tapRow, { justifyContent: 'center' }]}>
+                                            <Text>{hanzi.getPinyin(textHanyuDetail)[1]}</Text>
                                             <Ionicons name="volume-high" size={23} color="black" />
                                         </Pressable>
                                     </View>
-                            }
+                                )
+                            ) : (
+                                <Text>{/* fallback for web or if hanzi.getPinyin is not available */}</Text>
+                            )}
                         </View>
                         <View style={styles.triangle} />
                         <Text style={styles.tapPinyinText}>
-                            {textHanyuDetail && hanzi.definitionLookup(textHanyuDetail).map((w, i) => {
-                                return (i == 0 ? <Text key={i}>
-                                    {w.definition.split('/').slice(0, 3).join('/')}
-                                </Text> : null)
-                            })}
+                            {(typeof navigator !== 'undefined' && navigator.product === 'ReactNative' && typeof hanzi.definitionLookup === 'function') && textHanyuDetail
+                                ? hanzi.definitionLookup(textHanyuDetail).map((w, i) => (
+                                    i === 0 ? <Text key={i}>{w.definition.split('/').slice(0, 3).join('/')}</Text> : null
+                                ))
+                                : null}
                         </Text>
                     </View> : null
             }

--- a/components/ui/MultipleChoiceQuiz.js
+++ b/components/ui/MultipleChoiceQuiz.js
@@ -2,7 +2,7 @@ import { useStore } from '@/hooks/useStore';
 import hskData from '@assets/meta/hsk.json';
 import { Ionicons } from '@expo/vector-icons';
 import { useRoute } from '@react-navigation/native';
-import { Audio } from 'expo-audio';
+import { Audio } from 'expo-av';
 import { useEffect, useState } from 'react';
 import {
   Dimensions,

--- a/components/ui/TestTap.js
+++ b/components/ui/TestTap.js
@@ -2,7 +2,7 @@ import { View, Text, TextInput, StyleSheet } from 'react-native'
 import { useEffect, useState } from 'react'
 import { useBearsStore } from '@/hooks/useStore';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { Audio } from 'expo-audio';
+import { Audio } from 'expo-av';
 import { Pressable } from 'react-native';
 
 export default function TestTap(props) {

--- a/components/ui/TypingQuiz.js
+++ b/components/ui/TypingQuiz.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { StyleSheet, View, Text, Button, TouchableOpacity, Dimensions } from 'react-native';
 import hskData from '@assets/meta/hsk.json';
 import { useRoute } from '@react-navigation/native';
-import { Audio } from 'expo-audio';
+import { Audio } from 'expo-av';
 import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { useStore } from '@/hooks/useStore';
 import { TextInput } from 'react-native-gesture-handler';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Header is now visible with a bold “Home” title.
  - Quiz shows the current question number (e.g., “Question 3 / 10”).
  - On mobile, pinyin and definitions display when available; on web, unavailable elements are hidden for a cleaner experience, with adjusted secondary pinyin visibility.

- Style
  - Score text updated to red with added spacing; Submit button padding increased for a larger tap target.

- Chores
  - Migrated audio dependency to a new library across quiz/test components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->